### PR TITLE
fix node_modules/@dataui/crud/lib/interfaces/auth-options.interface.d.ts

### DIFF
--- a/packages/crud/src/interfaces/auth-options.interface.ts
+++ b/packages/crud/src/interfaces/auth-options.interface.ts
@@ -1,5 +1,5 @@
 import { SCondition } from '@dataui/crud-request/lib/types/request-query.types';
-import { ObjectLiteral } from 'crud-util/src';
+import { ObjectLiteral } from '@dataui/crud-util';
 
 export interface AuthGlobalOptions {
   property?: string;


### PR DESCRIPTION
fix. > nest build

node_modules/@dataui/crud/lib/interfaces/auth-options.interface.d.ts:2:31 - error TS2307: Cannot find module '@dataui/crud-util/src' or its corresponding type declarations.

2 import { ObjectLiteral } from '@dataui/crud-util/src';