### PR TITLE
Make custom property on options optional

### DIFF
--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -310,10 +310,10 @@ export class TypeOrmCrudService<T> extends CrudService<T, DeepPartial<T>> {
     builder.select(select);
 
     // search
-    this.setSearchCondition(builder, parsed.search, options.operators.custom);
+    this.setSearchCondition(builder, parsed.search, options.operators?.custom);
 
     // set joins
-    const joinOptions = options.query.join || {};
+    const joinOptions = options.query?.join || {};
     const allowedJoins = objKeys(joinOptions);
 
     if (hasLength(allowedJoins)) {
@@ -431,7 +431,7 @@ export class TypeOrmCrudService<T> extends CrudService<T, DeepPartial<T>> {
       : await this.createBuilder(parsed, options, true, withDeleted);
 
     if (shallow) {
-      this.setSearchCondition(builder, parsed.search, options.operators.custom);
+      this.setSearchCondition(builder, parsed.search, options.operators?.custom);
     }
 
     const found = withDeleted

--- a/packages/crud/src/interceptors/crud-request.interceptor.ts
+++ b/packages/crud/src/interceptors/crud-request.interceptor.ts
@@ -31,7 +31,7 @@ export class CrudRequestInterceptor extends CrudBaseInterceptor
         const { ctrlOptions, crudOptions, action } = this.getCrudInfo(context);
         const parser = RequestQueryParser.create();
 
-        parser.parseQuery(req.query, crudOptions.operators.custom);
+        parser.parseQuery(req.query, crudOptions.operators?.custom);
 
         if (!isNil(ctrlOptions)) {
           const search = this.getSearch(parser, crudOptions, action, req.params);


### PR DESCRIPTION
For instances where you have a custom controller that `implements CrudController<T>` with a custom endpoint that wants to use `TypeOrmCrudService<T>` it's nice to just be able to, for example, call

```ts
await this.service.getMany({
 options: { query: { limit: 10 } }
})
```

Without being required to pass in `operators`. At the moment the above would error with `can not read property 'custom' of undefined`