### PR TITLE
fix: Fix qs stringify sort array in querybuilder

### DIFF
--- a/packages/crud-request/src/request-query.builder.ts
+++ b/packages/crud-request/src/request-query.builder.ts
@@ -100,7 +100,7 @@ export class RequestQueryBuilder {
       this.queryObject[this.paramNames.filter] = undefined;
       this.queryObject[this.paramNames.or] = undefined;
     }
-    this.queryString = stringify(this.queryObject, { encode });
+    this.queryString = stringify(this.queryObject, { encode, indices: false });
     return this.queryString;
   }
 


### PR DESCRIPTION
Sort didnt work as expected. Stringified query was sort[0]=order,ASC&sort[1]=date,DESC and queryParser could not find sort keys