### PR TITLE
Fix: duplicate column selection issue in getMany with joins and pagination

### DIFF
--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -647,9 +647,11 @@ export class TypeOrmCrudService<T> extends CrudService<T, DeepPartial<T>> {
         : allowedRelation.allowedColumns;
 
       const select = [
-        ...allowedRelation.primaryColumns,
-        ...(isArrayFull(options.persist) ? options.persist : []),
-        ...columns,
+        ...new Set([
+          ...allowedRelation.primaryColumns,
+          ...(isArrayFull(options.persist) ? options.persist : []),
+          ...columns,
+        ]),
       ].map((col) => `${alias}.${col}`);
 
       builder.addSelect(Array.from(new Set(select)));
@@ -985,9 +987,11 @@ export class TypeOrmCrudService<T> extends CrudService<T, DeepPartial<T>> {
         : allowed;
 
     const select = [
-      ...(options.persist && options.persist.length ? options.persist : []),
-      ...columns,
-      ...this.entityPrimaryColumns,
+      ...new Set([
+        ...(options.persist && options.persist.length ? options.persist : []),
+        ...columns,
+        ...this.entityPrimaryColumns,
+      ]),
     ].map((col) => `${this.alias}.${col}`);
 
     return Array.from(new Set(select));


### PR DESCRIPTION
This pull request proposes a fix for the duplicate column names encountered when using getMany with joins and pagination in NestJS CRUD #788.

The current solution in #788 excludes the "id" column, which might not be ideal for all relational scenarios. This pull request aims to address duplication directly within the column array, preserving the "id" column when necessary or any duplicated column.

### Key points:

- [X] Solves duplicate column issue identified in #788.
- [X] Maintains "id" column inclusion for relational cases.
- [X] Implements logic to remove duplication within the column array.

**Please review and provide feedback on the proposed approach.**

issue #32