### PR TITLE
Fix Docker Compose Command in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: build docker db
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: install
         run: yarn install
@@ -38,7 +38,7 @@ jobs:
         run: yarn build
 
       - name: check docker
-        run: docker-compose up -d
+        run: docker compose up -d
 
       # Runs a set of commands using the runners shell
       - name: tests


### PR DESCRIPTION
This pull request corrects a minor typo in the main.yml file. The command used to start Docker Compose services has an extra hyphen before docker compose. This update removes the unnecessary hyphen for proper execution.

This change ensures the docker compose up -d command runs as intended, starting all defined services in detached mode.