### PR TITLE
fix: correctly extract major version from @nestjs/swagger

### DIFF
--- a/packages/crud/src/crud/swagger.helper.ts
+++ b/packages/crud/src/crud/swagger.helper.ts
@@ -594,7 +594,7 @@ export class Swagger {
 
   private static getSwaggerVersion(): number {
     return swaggerPkgJson
-      ? parseInt(swaggerPkgJson.version[0], 10)
+      ? parseInt(swaggerPkgJson.version.split('.')[0], 10)
       : /* istanbul ignore next */ 3;
   }
 }


### PR DESCRIPTION
With swagger v11 the parsing fails